### PR TITLE
Fix data format for ASR pipeline

### DIFF
--- a/11_future-directions.ipynb
+++ b/11_future-directions.ipynb
@@ -655,6 +655,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a3d7db63",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds.set_format(\"numpy\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "6aa96de7-2be8-4a26-bb1a-5ed4ee36fa62",
    "metadata": {},
    "outputs": [


### PR DESCRIPTION
The ASR pipeline in `transformers` expects NumPy arrays as input, but we only provide Python lists. This PR fixes the problem by setting the dataset format.

cc @lvwerra 