### PR TITLE
Fix install requirements for chapter 7

### DIFF
--- a/install.py
+++ b/install.py
@@ -12,13 +12,12 @@ def install_requirements(is_chapter7: bool = False, is_chapter10: bool = False, 
     """Installs the required packages for the project."""
 
     print("⏳ Installing base requirements ...")
+    cmd = ["python", "-m", "pip", "install", "-r"]
     if is_chapter7:
-        requirements = "requirements-chapter7.txt -f https://download.pytorch.org/whl/torch_stable.html".split()
+        cmd += "requirements-chapter7.txt -f https://download.pytorch.org/whl/torch_stable.html".split()
     else:
-        requirements = "requirements.txt"
-    process_install = subprocess.run(
-        ["python", "-m", "pip", "install", "-r", requirements], stdout=subprocess.PIPE, stderr=subprocess.PIPE
-    )
+        cmd.append("requirements.txt")
+    process_install = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     if process_install.returncode != 0:
         raise Exception("😭 Failed to install base requirements")
     else:


### PR DESCRIPTION
Previously, requirements would be an array when is_chapter7 was true.
In line 7, we were passing an array to subprocess.run. However, given
that requirements was an array, it would be an array within an array

The code was:
```
process_install = subprocess.run(
  ["python", "-m", "pip", "install", "-r", requirements], stdout=subprocess.PIPE, stderr=subprocess.PIPE
)
```
So, by requirements being an array, it would end up executing this:
```
process_install = subprocess.run(
  ["python", "-m", "pip", "install", "-r", ["requirements-chapter7.txt", "-f", "https://download.pytorch.org/whl/torch_stable.html"]], stdout=subprocess.PIPE, stderr=subprocess.PIPE
)
```
And thus it was erroring out with this message:
```TypeError: expected str, bytes or os.PathLike object, not list```