### PR TITLE
Ch. 01: Add hint for enabling internet access when running on Kaggle

### DIFF
--- a/01_introduction.ipynb
+++ b/01_introduction.ipynb
@@ -7,6 +7,8 @@
    "outputs": [],
    "source": [
     "# Uncomment and run this cell if you're on Colab or Kaggle\n",
+    "# On Kaggle you additionally need to enable internet access via the\n",
+    "#  settings drop-down menu on the right side after signing in\n",
     "# !git clone https://github.com/nlp-with-transformers/notebooks.git\n",
     "# %cd notebooks\n",
     "# from install import *\n",


### PR DESCRIPTION
Just as a proposal regarding the notebook for chapter 01: If the notebooks are run on Kaggle, it might be helpful for one or the other to give a hint on how to enable internet access to be able to clone the repository.