### PR TITLE
Add v2 of chapter 7 notebook which uses current haystack

### DIFF
--- a/install.py
+++ b/install.py
@@ -8,13 +8,16 @@ is_kaggle = "kaggle_secrets" in sys.modules
 torch_to_cuda = {"1.10.0": "cu113", "1.9.0": "cu111", "1.9.1": "cu111"}
 
 
-def install_requirements(is_chapter7: bool = False, is_chapter10: bool = False, is_chapter11: bool = False):
+def install_requirements(is_chapter7: bool = False, is_chapter10: bool = False, is_chapter11: bool = False, is_chapter7_v2: bool = False):
     """Installs the required packages for the project."""
 
     print("⏳ Installing base requirements ...")
     cmd = ["python", "-m", "pip", "install", "-r"]
     if is_chapter7:
         cmd += "requirements-chapter7.txt -f https://download.pytorch.org/whl/torch_stable.html".split()
+    elif is_chapter7_v2:
+        cmd.append("requirements-chapter7-v2.txt")
+        cmd = ["python", "-m", "pip", "install", "--upgrade", "pip", "&&"] + cmd
     else:
         cmd.append("requirements.txt")
     process_install = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/install.py
+++ b/install.py
@@ -17,7 +17,6 @@ def install_requirements(is_chapter7: bool = False, is_chapter10: bool = False, 
         cmd += "requirements-chapter7.txt -f https://download.pytorch.org/whl/torch_stable.html".split()
     elif is_chapter7_v2:
         cmd.append("requirements-chapter7-v2.txt")
-        cmd = ["python", "-m", "pip", "install", "--upgrade", "pip", "&&"] + cmd
     else:
         cmd.append("requirements.txt")
     process_install = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/install.py
+++ b/install.py
@@ -12,6 +12,7 @@ def install_requirements(
     is_chapter2: bool = False, 
     is_chapter6: bool = False,
     is_chapter7: bool = False,
+    is_chapter7_v2: bool = False,
     is_chapter10: bool = False,
     is_chapter11: bool = False
     ):

--- a/requirements-chapter7-v2.txt
+++ b/requirements-chapter7-v2.txt
@@ -1,0 +1,4 @@
+# Base requirements
+farm-haystack==1.4.0
+matplotlib
+datasets

--- a/requirements-chapter7-v2.txt
+++ b/requirements-chapter7-v2.txt
@@ -1,4 +1,4 @@
 # Base requirements
-farm-haystack==1.4.0
+farm-haystack[colab]==1.4.0
 matplotlib
 datasets


### PR DESCRIPTION
In the most recent version of Haystack, the evaluation of pipelines is much different compared to the version described in the (first edition of the) book. Pipeline now has a method eval(), which runs the pipeline given input data from labels and returns the prediction and the labels in the format of one pandas dataframe per pipeline node.
That's why we created a new second version of chapter 7's notebook which makes use of the new Haystack evaluation mechanism. The results of the evaluation between the first and the second version differ because in the previous notebook version there were two bugs: one within the notebook itself during creating the labels that made some labels disappear and one within haystack's previous evaluation logic that caused handling no_answers (e.g. when there is no answer to a certain question) in a improper way.

This PR:
- adds v2 of chapter 07: This contains updates of the haystack API and several bug fixes
- adds new `install_requirements` option `is_chapter7_v2`
- adds `requirements-chpater7-v2.txt` with `farm-haystack==1.4.0`

Misc:
- starting with Haystack 1.4.0 ElasticsearchRetriever is now called BM25Retriever