### PR TITLE
Ensure tensors are on the same device

### DIFF
--- a/08_model-compression.ipynb
+++ b/08_model-compression.ipynb
@@ -634,6 +634,8 @@
     "        self.teacher_model = teacher_model\n",
     "\n",
     "    def compute_loss(self, model, inputs, return_outputs=False):\n",
+    "        device = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
+    "        inputs = inputs.to(device)\n",
     "        outputs_stu = model(**inputs)\n",
     "        # Extract cross-entropy loss and logits from student\n",
     "        loss_ce = outputs_stu.loss\n",


### PR DESCRIPTION
Without this change, the notebook for chapter 8 breaks, if running on a GPU, when training the distillation model because the inputs are not on a GPU device.

<img width="1675" alt="image" src="https://user-images.githubusercontent.com/338917/187307661-fdd113b7-eb7a-4d27-9365-0fde8c9a63d6.png">